### PR TITLE
Lazy bytestring versions are insufficiently lazy

### DIFF
--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -267,7 +267,6 @@ reChunkIn :: Int -> [ByteString] -> [ByteString]
 reChunkIn !n = go
   where
     go [] = []
-    go [y] = [y]
     go (y : ys) = case B.length y `divMod` n of
                     (_, 0) -> y : go ys
                     (d, _) -> case B.splitAt (d * n) y of


### PR DESCRIPTION
A redundant case in `reChunkIn` always forces one more input chunk to be evaluated than necessary to generate an output chunk.

Before fix:

``` haskell
λ> encode ("foofoofoofoofoofoofoo" <> "barbarbarbarbarbarbar" <> undefined)
"Zm9vZm9vZm9vZm9vZm9vZm9vZm9v*** Exception: Prelude.undefined
```

After fix:

``` haskell
λ> encode ("foofoofoofoofoofoofoo" <> "barbarbarbarbarbarbar" <> undefined)
"Zm9vZm9vZm9vZm9vZm9vZm9vZm9vYmFyYmFyYmFyYmFyYmFyYmFyYmFy*** Exception: Prelude.undefined
```

(Actually, we should be able to do even better: from the first 3q + r input bytes, we should be able to generate the first 4q + r output bytes, not just the first 4q.  But that might require a bigger code reorganization.)
