### PR TITLE
Add variants without padding

### DIFF
--- a/Data/ByteString/Base64/Lazy/NoPadding.hs
+++ b/Data/ByteString/Base64/Lazy/NoPadding.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- |
+-- Module      : Data.ByteString.Base64.Lazy.NoPadding
+-- Copyright   : (c) 2012 Ian Lynagh
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Fast and efficient encoding and decoding of base64-encoded
+-- lazy bytestrings without padding.
+
+module Data.ByteString.Base64.Lazy.NoPadding
+    (
+      encode
+    , decode
+    , decodeLenient
+    ) where
+
+-- Except for the import of B64 the code of this module is a copy of
+-- "Data.ByteString.Base64.URL.Lazy"
+
+import Data.ByteString.Base64.Internal
+import qualified Data.ByteString.Base64.NoPadding as B64
+import qualified Data.ByteString                  as S
+import qualified Data.ByteString.Lazy             as L
+import qualified Data.ByteString.Lazy.Char8       as LC
+import Data.Char
+
+-- | Encode a string into base64 form without padding.
+encode :: L.ByteString -> L.ByteString
+encode = L.fromChunks . map B64.encode . reChunkIn 3 . L.toChunks
+
+-- | Decode a base64-encoded string without padding.  This function strictly follows
+-- the specification in RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>.
+decode :: L.ByteString -> Either String L.ByteString
+decode b = -- Returning an Either type means that the entire result will
+           -- need to be in memory at once anyway, so we may as well
+           -- keep it simple and just convert to and from a strict byte
+           -- string
+           -- TODO: Use L.{fromStrict,toStrict} once we can rely on
+           -- a new enough bytestring
+           case B64.decode $ S.concat $ L.toChunks b of
+           Left err -> Left err
+           Right b' -> Right $ L.fromChunks [b']
+
+-- | Decode a base64-encoded string without padding.  This function is lenient in
+-- following the specification from RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>, and will not generate
+-- parse errors no matter how poor its input.
+decodeLenient :: L.ByteString -> L.ByteString
+decodeLenient = L.fromChunks . map B64.decodeLenient . reChunkIn 4 . L.toChunks
+              . LC.filter goodChar
+    where -- We filter out and '=' padding here, but B64.decodeLenient
+          -- handles that
+          goodChar c = isAlphaNum c || c == '+' || c == '/'
+

--- a/Data/ByteString/Base64/NoPadding.hs
+++ b/Data/ByteString/Base64/NoPadding.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- |
+-- Module      : Data.ByteString.Base64.NoPadding
+-- Copyright   : (c) 2010 Bryan O'Sullivan
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Fast and efficient encoding and decoding of base64-encoded strings without padding.
+
+module Data.ByteString.Base64.NoPadding
+    (
+      encode
+    , decode
+    , decodeLenient
+    , joinWith
+    ) where
+
+import Data.ByteString.Base64.Internal
+import qualified Data.ByteString as B
+import Data.ByteString.Internal (ByteString(..))
+import Data.Word (Word8)
+import Foreign.ForeignPtr (ForeignPtr)
+
+-- | Encode a string into base64 form without padding.
+encode :: ByteString -> ByteString
+encode s = encodeWithInternal False (mkEncodeTable alphabet) s
+
+-- | Decode a base64-encoded string without padding.  This function strictly follows
+-- the specification in RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>.
+decode :: ByteString -> Either String ByteString
+decode s = decodeWithTableInternal False decodeFP s
+
+-- | Decode a base64-encoded string without padding.  This function is lenient in
+-- following the specification from RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>, and will not generate
+-- parse errors no matter how poor its input.
+decodeLenient :: ByteString -> ByteString
+decodeLenient s = decodeLenientWithTable decodeFP s
+
+alphabet :: ByteString
+alphabet = B.pack $ [65..90] ++ [97..122] ++ [48..57] ++ [43,47]
+{-# NOINLINE alphabet #-}
+
+decodeFP :: ForeignPtr Word8
+PS decodeFP _ _ = B.pack $
+  replicate 43 x ++ [62,x,x,x,63] ++ [52..61] ++ [x,x,x,done,x,x,x] ++
+  [0..25] ++ [x,x,x,x,x,x] ++ [26..51] ++ replicate 133 x
+{-# NOINLINE decodeFP #-}
+
+x :: Integral a => a
+x = 255
+{-# INLINE x #-}

--- a/Data/ByteString/Base64/URL/Lazy/NoPadding.hs
+++ b/Data/ByteString/Base64/URL/Lazy/NoPadding.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- |
+-- Module      : Data.ByteString.Base64.URL.Lazy.NoPadding
+-- Copyright   : (c) 2012 Ian Lynagh
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Fast and efficient encoding and decoding of base64-encoded
+-- lazy bytestrings without padding.
+
+module Data.ByteString.Base64.URL.Lazy.NoPadding
+    (
+      encode
+    , decode
+    , decodeLenient
+    ) where
+
+-- Except for the import of B64 the code of this module is a copy of
+-- "Data.ByteString.Base64.URL.Lazy"
+
+import Data.ByteString.Base64.Internal
+import qualified Data.ByteString.Base64.URL.NoPadding as B64
+import qualified Data.ByteString                      as S
+import qualified Data.ByteString.Lazy                 as L
+import qualified Data.ByteString.Lazy.Char8           as LC
+import Data.Char
+
+-- | Encode a string into base64 form without padding.
+encode :: L.ByteString -> L.ByteString
+encode = L.fromChunks . map B64.encode . reChunkIn 3 . L.toChunks
+
+-- | Decode a base64-encoded string without padding.  This function strictly
+-- follows the specification in RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>.
+decode :: L.ByteString -> Either String L.ByteString
+decode b = -- Returning an Either type means that the entire result will
+           -- need to be in memory at once anyway, so we may as well
+           -- keep it simple and just convert to and from a strict byte
+           -- string
+           -- TODO: Use L.{fromStrict,toStrict} once we can rely on
+           -- a new enough bytestring
+           case B64.decode $ S.concat $ L.toChunks b of
+           Left err -> Left err
+           Right b' -> Right $ L.fromChunks [b']
+
+-- | Decode a base64-encoded string without padding.  This function is lenient
+-- in following the specification from RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>, and will not generate
+-- parse errors no matter how poor its input.
+decodeLenient :: L.ByteString -> L.ByteString
+decodeLenient = L.fromChunks . map B64.decodeLenient . reChunkIn 4 . L.toChunks
+              . LC.filter goodChar
+    where -- We filter out and '=' padding here, but B64.decodeLenient
+          -- handles that
+          goodChar c = isAlphaNum c || c == '-' || c == '_'
+

--- a/Data/ByteString/Base64/URL/NoPadding.hs
+++ b/Data/ByteString/Base64/URL/NoPadding.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- |
+-- Module      : Data.ByteString.Base64.URL.NoPadding
+-- Copyright   : (c) 2012 Deian Stefan
+--
+-- License     : BSD-style
+-- Maintainer  : deian@cs.stanford.edu
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Fast and efficient encoding and decoding of base64url-encoded strings without padding.
+
+module Data.ByteString.Base64.URL.NoPadding
+    (
+      encode
+    , decode
+    , decodeLenient
+    , joinWith
+    ) where
+
+import Data.ByteString.Base64.Internal
+import qualified Data.ByteString as B
+import Data.ByteString.Internal (ByteString(..))
+import Data.Word (Word8)
+import Foreign.ForeignPtr (ForeignPtr)
+
+-- | Encode a string into base64url form without padding.
+encode :: ByteString -> ByteString
+encode = encodeWithInternal False (mkEncodeTable alphabet)
+
+-- | Decode a base64url-encoded string without padding.  This function strictly
+-- follows the specification in RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>.
+decode :: ByteString -> Either String ByteString
+decode = decodeWithTableInternal False decodeFP
+
+-- | Decode a base64url-encoded string without padding.  This function is
+-- lenient in following the specification from RFC 4648,
+-- <http://www.apps.ietf.org/rfc/rfc4648.html>, and will not generate
+-- parse errors no matter how poor its input.
+decodeLenient :: ByteString -> ByteString
+decodeLenient = decodeLenientWithTable decodeFP
+
+alphabet :: ByteString
+alphabet = B.pack $ [65..90] ++ [97..122] ++ [48..57] ++ [45,95]
+{-# NOINLINE alphabet #-}
+
+decodeFP :: ForeignPtr Word8
+PS decodeFP _ _ = B.pack $ replicate 45 x ++ [62,x,x] ++ [52..61] ++ [x,x,
+  x,done,x,x,x] ++ [0..25] ++ [x,x,x,x,63,x] ++ [26..51] ++ replicate 133 x
+{-# NOINLINE decodeFP #-}
+
+x :: Integral a => a
+x = 255
+{-# INLINE x #-}

--- a/base64-bytestring.cabal
+++ b/base64-bytestring.cabal
@@ -22,9 +22,13 @@ extra-source-files:
 library
   exposed-modules:
     Data.ByteString.Base64
+    Data.ByteString.Base64.NoPadding
     Data.ByteString.Base64.URL
+    Data.ByteString.Base64.URL.NoPadding
     Data.ByteString.Base64.Lazy
+    Data.ByteString.Base64.Lazy.NoPadding
     Data.ByteString.Base64.URL.Lazy
+    Data.ByteString.Base64.URL.Lazy.NoPadding
   
   other-modules:
     Data.ByteString.Base64.Internal


### PR DESCRIPTION
Section 3.2 of RFC 4648 notes that the padding of base64 encoded data may be omitted when the length of the encoded data is known implicitly. This is the case for many applications that require a textual encoding of binary data. Examples include JSON and URLs.  
