### PR TITLE
Relaxed constrain on base to make it build on 7.8.3

### DIFF
--- a/base64-bytestring.cabal
+++ b/base64-bytestring.cabal
@@ -1,5 +1,5 @@
 name:                base64-bytestring
-version:             1.0.0.1
+version:             1.0.0.2
 synopsis:            Fast base64 encoding and decoding for ByteStrings
 description:         Fast base64 encoding and decoding for ByteStrings
 homepage:            https://github.com/bos/base64-bytestring
@@ -30,7 +30,7 @@ library
     Data.ByteString.Base64.Internal
 
   build-depends:
-    base == 4.*,
+    base >= 4.0.0.0 && < 5,
     bytestring >= 0.9.0
 
   ghc-options: -Wall -funbox-strict-fields


### PR DESCRIPTION
Hi @bos ,

this patch trivially relax the cabal constrain on base to make the package buildable on 7.8.3.

Two things:

a) I have bumped the package version. Shout if I need to revert this, most maintainers prefers to do a separate release and bump it themselves

b) Would be possible in the meantime to use the new feature of Hackage to amend the live manifest on 1.0.0.1 so that it builds on 7.8.3?

Thanks!

Alfredo
