### PR TITLE
Remove isAlphaNum in LBS decodeLenient

### DIFF
--- a/Data/ByteString/Base64/Lazy.hs
+++ b/Data/ByteString/Base64/Lazy.hs
@@ -57,4 +57,5 @@ decodeLenient = L.fromChunks . map B64.decodeLenient . reChunkIn 4 . L.toChunks
               . LC.filter goodChar
     where -- We filter out and '=' padding here, but B64.decodeLenient
           -- handles that
-          goodChar c = isAlphaNum c || c == '+' || c == '/'
+          goodChar c = isDigit c || isAsciiUpper c || isAsciiLower c
+                                 || c == '+' || c == '/'

--- a/Data/ByteString/Base64/URL/Lazy.hs
+++ b/Data/ByteString/Base64/URL/Lazy.hs
@@ -58,3 +58,4 @@ decodeLenient = L.fromChunks . map B64.decodeLenient . reChunkIn 4 . L.toChunks
     where -- We filter out and '=' padding here, but B64.decodeLenient
           -- handles that
           goodChar c = isAlphaNum c || c == '-' || c == '_'
+

--- a/benchmarks/BM.hs
+++ b/benchmarks/BM.hs
@@ -5,6 +5,7 @@ import Criterion.Main
 import qualified Data.ByteString.Base64 as B
 import qualified Data.ByteString.Base64.Lazy as L
 import qualified Data.ByteString.Base64.URL as U
+import qualified Data.ByteString.Base64.URL.Lazy as LU
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as L
 
@@ -38,8 +39,16 @@ instance NFData L.ByteString where
 lazy :: String -> L.ByteString -> Benchmark
 lazy name orig =
     bgroup name [
-      bench "decode" $ nf L.decode enc
-    , bench "encode" $ nf L.encode orig
+      bgroup "normal" [
+        bench "decode" $ nf L.decode enc
+      , bench "decodeLenient" $ nf L.decodeLenient enc
+      , bench "encode" $ nf L.encode orig
+      ]
+    , bgroup "url" [
+        bench "decode" $ nf LU.decode enc
+      , bench "decodeLenient" $ nf LU.decodeLenient enc
+      , bench "encode" $ nf LU.encode orig
+      ]
     ]
   where enc = L.encode orig
 


### PR DESCRIPTION
Using isAlphaNum makes decodeLenient much slower that it should be.
Rechunking also must be incorrect if non-ASCII characters are accepted instead of being filtered.
This PR replaces the call by simpler ASCII-only functions.

Before:
```
benchmarking lazy/large/normal/decode
time                 367.4 μs   (366.8 μs .. 368.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 367.3 μs   (366.7 μs .. 367.8 μs)
std dev              1.810 μs   (1.486 μs .. 2.328 μs)

benchmarking lazy/large/normal/decodeLenient
time                 6.071 ms   (6.055 ms .. 6.084 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.063 ms   (6.055 ms .. 6.071 ms)
std dev              24.26 μs   (19.38 μs .. 31.04 μs)
```

After:
```
benchmarking lazy/large/normal/decode
time                 367.3 μs   (366.8 μs .. 367.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 367.8 μs   (367.2 μs .. 368.4 μs)
std dev              1.921 μs   (1.597 μs .. 2.595 μs)

benchmarking lazy/large/normal/decodeLenient
time                 1.516 ms   (1.514 ms .. 1.518 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.517 ms   (1.516 ms .. 1.519 ms)
std dev              5.706 μs   (4.445 μs .. 7.802 μs)
```
