### PR TITLE
Add unpadded encode/decode variants

### DIFF
--- a/Data/ByteString/Base64.hs
+++ b/Data/ByteString/Base64.hs
@@ -31,7 +31,7 @@ import Foreign.ForeignPtr (ForeignPtr)
 -- | Encode a string into base64 form.  The result will always be a
 -- multiple of 4 bytes in length.
 encode :: ByteString -> ByteString
-encode s = encodeWith (mkEncodeTable alphabet) s
+encode s = encodeWith True (mkEncodeTable alphabet) s
 
 -- | Decode a base64-encoded string. This function strictly follows
 -- the specification in
@@ -42,7 +42,7 @@ encode s = encodeWith (mkEncodeTable alphabet) s
 -- standard that overrules RFC 4648 such as HTTP multipart mime bodies,
 -- consider using 'decodeLenient'.)
 decode :: ByteString -> Either String ByteString
-decode s = decodeWithTable decodeFP s
+decode s = decodeWithTable False decodeFP s
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64.hs
+++ b/Data/ByteString/Base64.hs
@@ -31,7 +31,7 @@ import Foreign.ForeignPtr (ForeignPtr)
 -- | Encode a string into base64 form.  The result will always be a
 -- multiple of 4 bytes in length.
 encode :: ByteString -> ByteString
-encode s = encodeWith True (mkEncodeTable alphabet) s
+encode s = encodeWith Padded (mkEncodeTable alphabet) s
 
 -- | Decode a base64-encoded string. This function strictly follows
 -- the specification in
@@ -42,7 +42,7 @@ encode s = encodeWith True (mkEncodeTable alphabet) s
 -- standard that overrules RFC 4648 such as HTTP multipart mime bodies,
 -- consider using 'decodeLenient'.)
 decode :: ByteString -> Either String ByteString
-decode s = decodeWithTable False decodeFP s
+decode s = decodeWithTable Unpadded decodeFP s
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -45,8 +45,8 @@ peek8_32 = fmap fromIntegral . peek8
 
 -- | Encode a string into base64 form.  The result will always be a multiple
 -- of 4 bytes in length.
-encodeWith :: EncodeTable -> ByteString -> ByteString
-encodeWith (ET alfaFP encodeTable) (PS sfp soff slen)
+encodeWith :: Bool -> EncodeTable -> ByteString -> ByteString
+encodeWith !padding (ET alfaFP encodeTable) (PS sfp soff slen)
     | slen > maxBound `div` 4 =
         error "Data.ByteString.Base64.encode: input too long"
     | otherwise = unsafePerformIO $ do
@@ -57,8 +57,9 @@ encodeWith (ET alfaFP encodeTable) (PS sfp soff slen)
       withForeignPtr sfp $ \sptr -> do
         let aidx n = peek8 (aptr `plusPtr` n)
             sEnd = sptr `plusPtr` (slen + soff)
-            fill !dp !sp
-              | sp `plusPtr` 2 >= sEnd = complete (castPtr dp) sp
+            finish !n = return (PS dfp 0 n)
+            fill !dp !sp !n
+              | sp `plusPtr` 2 >= sEnd = complete (castPtr dp) sp n
               | otherwise = {-# SCC "encode/fill" #-} do
               i <- peek8_32 sp
               j <- peek8_32 (sp `plusPtr` 1)
@@ -67,29 +68,42 @@ encodeWith (ET alfaFP encodeTable) (PS sfp soff slen)
                   enc = peekElemOff ep . fromIntegral
               poke dp =<< enc (w `shiftR` 12)
               poke (dp `plusPtr` 2) =<< enc (w .&. 0xfff)
-              fill (dp `plusPtr` 4) (sp `plusPtr` 3)
-            complete dp sp
-                | sp == sEnd = return ()
+              fill (dp `plusPtr` 4) (sp `plusPtr` 3) (n + 4)
+            complete dp sp n
+                | sp == sEnd = finish n
                 | otherwise  = {-# SCC "encode/complete" #-} do
-              let peekSP n f = (f . fromIntegral) `fmap` peek8 (sp `plusPtr` n)
+              let peekSP m f = (f . fromIntegral) `fmap` peek8 (sp `plusPtr` m)
                   twoMore    = sp `plusPtr` 2 == sEnd
                   equals     = 0x3d :: Word8
                   {-# INLINE equals #-}
               !a <- peekSP 0 ((`shiftR` 2) . (.&. 0xfc))
               !b <- peekSP 0 ((`shiftL` 4) . (.&. 0x03))
-              !b' <- if twoMore
-                     then peekSP 1 ((.|. b) . (`shiftR` 4) . (.&. 0xf0))
-                     else return b
+
               poke8 dp =<< aidx a
-              poke8 (dp `plusPtr` 1) =<< aidx b'
-              !c <- if twoMore
-                    then aidx =<< peekSP 1 ((`shiftL` 2) . (.&. 0x0f))
-                    else return equals
-              poke8 (dp `plusPtr` 2) c
-              poke8 (dp `plusPtr` 3) equals
+
+              if twoMore
+                then do
+                  !b' <- peekSP 1 ((.|. b) . (`shiftR` 4) . (.&. 0xf0))
+                  !c <- aidx =<< peekSP 1 ((`shiftL` 2) . (.&. 0x0f))
+                  poke8 (dp `plusPtr` 1) =<< aidx b'
+                  poke8 (dp `plusPtr` 2) c
+
+                  if padding
+                    then poke8 (dp `plusPtr` 3) equals >> finish (n + 4)
+                    else finish (n + 3)
+                else do
+                  poke8 (dp `plusPtr` 1) =<< aidx b
+
+                  if padding
+                    then do
+                      poke8 (dp `plusPtr` 2) equals
+                      poke8 (dp `plusPtr` 3) equals
+                      finish (n + 4)
+                    else finish (n + 2)
+
+
         withForeignPtr dfp $ \dptr ->
-          fill (castPtr dptr) (sptr `plusPtr` soff)
-  return $! PS dfp 0 dlen
+          fill (castPtr dptr) (sptr `plusPtr` soff) 0
 
 data EncodeTable = ET (ForeignPtr Word8) (ForeignPtr Word16)
 
@@ -152,53 +166,56 @@ joinWith brk@(PS bfp boff blen) every' bs@(PS sfp soff slen)
 -- <http://tools.ietf.org/rfc/rfc4648 RFC 4648>.
 -- This function takes the decoding table (for @base64@ or @base64url@) as
 -- the first paramert.
-decodeWithTable :: ForeignPtr Word8 -> ByteString -> Either String ByteString
-decodeWithTable decodeFP (PS sfp soff slen)
-    | drem /= 0 = Left "invalid padding"
+decodeWithTable :: Bool -> ForeignPtr Word8 -> ByteString -> Either String ByteString
+decodeWithTable padding decodeFP bs
+    | padding = go (B.append bs (B.replicate drem 0x3d))
+    | drem /= 0 && (not padding) = Left "invalid padding"
     | dlen <= 0 = Right B.empty
-    | otherwise = unsafePerformIO $ do
-  dfp <- mallocByteString dlen
-  withForeignPtr decodeFP $ \ !decptr -> do
-    let finish dbytes = return . Right $! if dbytes > 0
-                                          then PS dfp 0 dbytes
-                                          else B.empty
-        bail = return . Left
-    withForeignPtr sfp $ \ !sptr -> do
-      let sEnd = sptr `plusPtr` (slen + soff)
-          look p = do
-            ix <- fromIntegral `fmap` peek8 p
-            v <- peek8 (decptr `plusPtr` ix)
-            return $! fromIntegral v :: IO Word32
-          fill !dp !sp !n
-            | sp >= sEnd = finish n
-            | otherwise = {-# SCC "decodeWithTable/fill" #-} do
-            a <- look sp
-            b <- look (sp `plusPtr` 1)
-            c <- look (sp `plusPtr` 2)
-            d <- look (sp `plusPtr` 3)
-            let w = (a `shiftL` 18) .|. (b `shiftL` 12) .|.
-                    (c `shiftL` 6) .|. d
-            if a == done || b == done
-              then bail $ "invalid padding near offset " ++
-                   show (sp `minusPtr` sptr)
-              else if a .|. b .|. c .|. d == x
-              then bail $ "invalid base64 encoding near offset " ++
-                   show (sp `minusPtr` sptr)
-              else do
-                poke8 dp $ fromIntegral (w `shiftR` 16)
-                if c == done
-                  then finish $ n + 1
+    | otherwise = go bs
+  where
+    (di,drem) = (B.length bs) `divMod` 4
+    dlen = di * 3
+    go (PS sfp soff slen) = unsafePerformIO $ do
+      dfp <- mallocByteString dlen
+      withForeignPtr decodeFP $ \ !decptr -> do
+        let finish dbytes = return . Right $! if dbytes > 0
+                                              then PS dfp 0 dbytes
+                                              else B.empty
+            bail = return . Left
+        withForeignPtr sfp $ \ !sptr -> do
+          let sEnd = sptr `plusPtr` (slen + soff)
+              look p = do
+                ix <- fromIntegral `fmap` peek8 p
+                v <- peek8 (decptr `plusPtr` ix)
+                return $! fromIntegral v :: IO Word32
+              fill !dp !sp !n
+                | sp >= sEnd = finish n
+                | otherwise = {-# SCC "decodeWithTable/fill" #-} do
+                a <- look sp
+                b <- look (sp `plusPtr` 1)
+                c <- look (sp `plusPtr` 2)
+                d <- look (sp `plusPtr` 3)
+                let w = (a `shiftL` 18) .|. (b `shiftL` 12) .|.
+                        (c `shiftL` 6) .|. d
+                if a == done || b == done
+                  then bail $ "invalid padding near offset " ++
+                       show (sp `minusPtr` sptr)
+                  else if a .|. b .|. c .|. d == x
+                  then bail $ "invalid base64 encoding near offset " ++
+                       show (sp `minusPtr` sptr)
                   else do
-                    poke8 (dp `plusPtr` 1) $ fromIntegral (w `shiftR` 8)
-                    if d == done
-                      then finish $! n + 2
+                    poke8 dp $ fromIntegral (w `shiftR` 16)
+                    if c == done
+                      then finish $ n + 1
                       else do
-                        poke8 (dp `plusPtr` 2) $ fromIntegral w
-                        fill (dp `plusPtr` 3) (sp `plusPtr` 4) (n+3)
-      withForeignPtr dfp $ \dptr ->
-        fill dptr (sptr `plusPtr` soff) 0
-  where (di,drem) = slen `divMod` 4
-        dlen = di * 3
+                        poke8 (dp `plusPtr` 1) $ fromIntegral (w `shiftR` 8)
+                        if d == done
+                          then finish $! n + 2
+                          else do
+                            poke8 (dp `plusPtr` 2) $ fromIntegral w
+                            fill (dp `plusPtr` 3) (sp `plusPtr` 4) (n+3)
+          withForeignPtr dfp $ \dptr ->
+            fill dptr (sptr `plusPtr` soff) 0
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/URL.hs
+++ b/Data/ByteString/Base64/URL.hs
@@ -32,17 +32,17 @@ import Foreign.ForeignPtr (ForeignPtr)
 -- | Encode a string into base64url form.  The result will always be a
 -- multiple of 4 bytes in length.
 encode :: ByteString -> ByteString
-encode = encodeWith True (mkEncodeTable alphabet)
+encode = encodeWith Padded (mkEncodeTable alphabet)
 
 -- | Encode a string into unpadded base64url form.
 encodeUnpadded :: ByteString -> ByteString
-encodeUnpadded = encodeWith False (mkEncodeTable alphabet)
+encodeUnpadded = encodeWith Unpadded (mkEncodeTable alphabet)
 
 -- | Decode a base64url-encoded string applying padding if necessary.
 -- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
 -- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
 decode :: ByteString -> Either String ByteString
-decode = decodeWithTable True decodeFP
+decode = decodeWithTable Padded decodeFP
 
 -- | Decode a base64url-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/URL.hs
+++ b/Data/ByteString/Base64/URL.hs
@@ -17,6 +17,7 @@
 module Data.ByteString.Base64.URL
     (
       encode
+    , encodeUnpadded
     , decode
     , decodeLenient
     , joinWith
@@ -31,13 +32,17 @@ import Foreign.ForeignPtr (ForeignPtr)
 -- | Encode a string into base64url form.  The result will always be a
 -- multiple of 4 bytes in length.
 encode :: ByteString -> ByteString
-encode = encodeWith (mkEncodeTable alphabet)
+encode = encodeWith True (mkEncodeTable alphabet)
 
--- | Decode a base64url-encoded string.  This function strictly follows
--- the specification in
--- <http://tools.ietf.org/rfc/rfc4648 RFC 4648>.
+-- | Encode a string into unpadded base64url form.
+encodeUnpadded :: ByteString -> ByteString
+encodeUnpadded = encodeWith False (mkEncodeTable alphabet)
+
+-- | Decode a base64url-encoded string applying padding if necessary.
+-- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
+-- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
 decode :: ByteString -> Either String ByteString
-decode = decodeWithTable decodeFP
+decode = decodeWithTable True decodeFP
 
 -- | Decode a base64url-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/URL/Lazy.hs
+++ b/Data/ByteString/Base64/URL/Lazy.hs
@@ -18,6 +18,7 @@
 module Data.ByteString.Base64.URL.Lazy
     (
       encode
+    , encodeUnpadded
     , decode
     , decodeLenient
     ) where
@@ -33,6 +34,13 @@ import Data.Char
 -- multiple of 4 bytes in length.
 encode :: L.ByteString -> L.ByteString
 encode = L.fromChunks . map B64.encode . reChunkIn 3 . L.toChunks
+
+-- | Encode a string into unpadded base64url form.
+encodeUnpadded :: L.ByteString -> L.ByteString
+encodeUnpadded = L.fromChunks
+    . map B64.encodeUnpadded
+    . reChunkIn 3
+    . L.toChunks
 
 -- | Decode a base64-encoded string.  This function strictly follows
 -- the specification in
@@ -58,4 +66,3 @@ decodeLenient = L.fromChunks . map B64.decodeLenient . reChunkIn 4 . L.toChunks
     where -- We filter out and '=' padding here, but B64.decodeLenient
           -- handles that
           goodChar c = isAlphaNum c || c == '-' || c == '_'
-

--- a/benchmarks/BM.hs
+++ b/benchmarks/BM.hs
@@ -26,6 +26,7 @@ strict name orig =
         bench "decode" $ whnf U.decode enc
       , bench "decodeLenient" $ whnf U.decodeLenient enc
       , bench "encode" $ whnf U.encode orig
+      , bench "encodeUnpadded" $ whnf U.encodeUnpadded orig
       ]
     ]
   where enc = U.encode orig
@@ -48,6 +49,7 @@ lazy name orig =
         bench "decode" $ nf LU.decode enc
       , bench "decodeLenient" $ nf LU.decodeLenient enc
       , bench "encode" $ nf LU.encode orig
+      , bench "encodeUnpadded" $ whnf LU.encodeUnpadded orig
       ]
     ]
   where enc = L.encode orig

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -146,10 +146,6 @@ base64url_testData = [("",                "")
                      ,("Example",         "RXhhbXBsZQ==")
                      ,("Ex\0am\254ple",   "RXgAYW3-cGxl")
                      ,("Ex\0am\255ple",   "RXgAYW3_cGxl")
-                     -- padding fluidity cases
-                     ,("Sunn",            "U3Vubg")
-                     ,("Sunn",            "U3Vubg=")
-                     ,("Sunn",            "U3Vubg==") -- actual correct case
                      ]
 
 -- | Generic test given encod enad decode funstions and a

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -146,6 +146,10 @@ base64url_testData = [("",                "")
                      ,("Example",         "RXhhbXBsZQ==")
                      ,("Ex\0am\254ple",   "RXgAYW3-cGxl")
                      ,("Ex\0am\255ple",   "RXgAYW3_cGxl")
+                     -- padding fluidity cases
+                     ,("Sunn",            "U3Vubg")
+                     ,("Sunn",            "U3Vubg=")
+                     ,("Sunn",            "U3Vubg==") -- actual correct case
                      ]
 
 -- | Generic test given encod enad decode funstions and a
@@ -192,4 +196,3 @@ instance AllRepresentations L.ByteString where
                              -- The last split (empty suffix) gives us the
                              -- [b] case (toChunks ignores an "" element).
                            , (prefix, suffix) <- tail splits ]
-


### PR DESCRIPTION
This a slightly more invasive PR than #14, but with no code duplication. It adds an optional padding flag to the internals allowing for bytestrings to be encoded without padding, and decoded by being padded out to a multiple of 4 if the flag is set to `True` in either function. The motivation for this was described in https://github.com/haskell/base64-bytestring/issues/18

This PR is mostly additive, and the user only sees the addition of the `encodeUnpadded` function. If you're tentative about changing the semantics of `URL/decode`, then i'd be happy to add an additional variant `decodeUnpadded` which makes the choice to decode by padding out bytes explicit, keeping the semantic of `decode` unchanged.

@hvr @23Skidoo 