### PR TITLE
Bug Fix: Restrict active padding to valid lengths + decodeUnpadded + decodePadded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.1.0 (WIP)
 
-* Added unpadded encode/decode variants
+* Added strict unpadded and padded decode functions for Base64url ([#30](https://github.com/haskell/base64-bytestring/pull/30))
+* Added unpadded encode for Base64url
   ([#26](https://github.com/haskell/base64-bytestring/pull/26)).
 
 # 1.0.0.3

--- a/Data/ByteString/Base64.hs
+++ b/Data/ByteString/Base64.hs
@@ -42,7 +42,7 @@ encode s = encodeWith Padded (mkEncodeTable alphabet) s
 -- standard that overrules RFC 4648 such as HTTP multipart mime bodies,
 -- consider using 'decodeLenient'.)
 decode :: ByteString -> Either String ByteString
-decode s = decodeWithTable Unpadded decodeFP s
+decode s = decodeWithTable Padded decodeFP s
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -201,7 +201,7 @@ decodeWithTable padding decodeFP bs@(PS !fp !o !l) = unsafePerformIO $
       b <- peek (plusPtr p (end - 2))
 
       let !pad = 0x3d :: Word8
-      if a == pad && b == pad
+      if a == pad || b == pad
       then err "Base64-encoded bytestring required to be unpadded"
       else io
 

--- a/Data/ByteString/Base64/URL.hs
+++ b/Data/ByteString/Base64/URL.hs
@@ -19,6 +19,8 @@ module Data.ByteString.Base64.URL
       encode
     , encodeUnpadded
     , decode
+    , decodePadded
+    , decodeUnpadded
     , decodeLenient
     , joinWith
     ) where
@@ -42,7 +44,19 @@ encodeUnpadded = encodeWith Unpadded (mkEncodeTable alphabet)
 -- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
 -- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
 decode :: ByteString -> Either String ByteString
-decode = decodeWithTable Padded decodeFP
+decode = decodeWithTable Don'tCare decodeFP
+
+-- | Decode a padded base64url-encoded string, failing if input is improperly padded.
+-- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
+-- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
+decodePadded :: ByteString -> Either String ByteString
+decodePadded = decodeWithTable Padded decodeFP
+
+-- | Decode a unpadded base64url-encoded string, failing if input is padded.
+-- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
+-- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
+decodeUnpadded :: ByteString -> Either String ByteString
+decodeUnpadded = decodeWithTable Unpadded decodeFP
 
 -- | Decode a base64url-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/URL/Lazy.hs
+++ b/Data/ByteString/Base64/URL/Lazy.hs
@@ -20,6 +20,8 @@ module Data.ByteString.Base64.URL.Lazy
       encode
     , encodeUnpadded
     , decode
+    , decodeUnpadded
+    , decodePadded
     , decodeLenient
     ) where
 
@@ -55,6 +57,22 @@ decode b = -- Returning an Either type means that the entire result will
            case B64.decode $ S.concat $ L.toChunks b of
            Left err -> Left err
            Right b' -> Right $ L.fromChunks [b']
+
+-- | Decode a unpadded base64url-encoded string, failing if input is padded.
+-- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
+-- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
+decodeUnpadded :: L.ByteString -> Either String L.ByteString
+decodeUnpadded bs = case B64.decodeUnpadded $ S.concat $ L.toChunks bs of
+  Right b -> Right $ L.fromChunks [b]
+  Left e -> Left e
+
+-- | Decode a padded base64url-encoded string, failing if input is improperly padded.
+-- This function follows the specification in <http://tools.ietf.org/rfc/rfc4648 RFC 4648>
+-- and in <https://tools.ietf.org/html/rfc7049#section-2.4.4.2 RFC 7049 2.4>
+decodePadded :: L.ByteString -> Either String L.ByteString
+decodePadded bs = case B64.decodePadded $ S.concat $ L.toChunks bs of
+  Right b -> Right $ L.fromChunks [b]
+  Left e -> Left e
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -38,10 +38,12 @@ tests = [
       , testProperty "endsWith" joinWith_endsWith
       , testProperty "pureImpl" joinWith_pureImpl
     ]
-  , testsRegular $ Impl "Base64"     Base64.encode     Base64.decode     Base64.decodeLenient
-  , testsRegular $ Impl "LBase64"    LBase64.encode    LBase64.decode    LBase64.decodeLenient
-  , testsURL     $ Impl "Base64URL"  Base64URL.encode  Base64URL.decode  Base64URL.decodeLenient
-  , testsURL     $ Impl "LBase64URL" LBase64URL.encode LBase64URL.decode LBase64URL.decodeLenient
+  , testsRegular $ Impl "Base64" Base64.encode Base64.decode Base64.decodeLenient
+  , testsRegular $ Impl "LBase64" LBase64.encode LBase64.decode LBase64.decodeLenient
+  , testsURL $ Impl "Base64URL" Base64URL.encode Base64URL.decode Base64URL.decodeLenient
+  , testsURL $ Impl "LBase64URL" LBase64URL.encode LBase64URL.decode LBase64URL.decodeLenient
+  , testsURL $ Impl "Base64URLPadded" Base64URL.encode Base64URL.decodePadded Base64URL.decodeLenient
+  , testsURLNopad $ Impl "Base64URLUnpadded" Base64URL.encodeUnpadded Base64URL.decodeUnpadded Base64URL.decodeLenient
   ]
 
 testsRegular :: (IsString bs, AllRepresentations bs, Show bs, Eq bs, Arbitrary bs) => Impl bs -> Test
@@ -49,6 +51,9 @@ testsRegular = testsWith base64_testData
 
 testsURL :: (IsString bs, AllRepresentations bs, Show bs, Eq bs, Arbitrary bs) => Impl bs -> Test
 testsURL = testsWith base64url_testData
+
+testsURLNopad :: (IsString bs, AllRepresentations bs, Show bs, Eq bs, Arbitrary bs) => Impl bs -> Test
+testsURLNopad = testsWith base64url_testData_nopad
 
 testsWith :: (IsString bs, AllRepresentations bs, Show bs, Eq bs, Arbitrary bs)
           => [(bs, bs)] -> Impl bs -> Test
@@ -148,6 +153,20 @@ base64url_testData = [("",                "")
                      ,("Ex\0am\255ple",   "RXgAYW3_cGxl")
                      ]
 
+base64url_testData_nopad :: IsString bs => [(bs, bs)]
+base64url_testData_nopad = [("",                "")
+                           ,("\0",              "AA")
+                           ,("\255",            "_w")
+                           ,("E",               "RQ")
+                           ,("Ex",              "RXg")
+                           ,("Exa",             "RXhh")
+                           ,("Exam",            "RXhhbQ")
+                           ,("Examp",           "RXhhbXA")
+                           ,("Exampl",          "RXhhbXBs")
+                           ,("Example",         "RXhhbXBsZQ")
+                           ,("Ex\0am\254ple",   "RXgAYW3-cGxl")
+                           ,("Ex\0am\255ple",   "RXgAYW3_cGxl")
+                           ]
 -- | Generic test given encod enad decode funstions and a
 -- list of (plain, encoded) pairs
 base64_string_test :: (AllRepresentations bs, Eq bs, Show bs)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -238,20 +238,19 @@ base64_string_test
 base64_string_test enc dec testData =
       [ testCase ("base64-string: Encode " ++ show plain)
                  (encoded_plain @?= rawEncoded)
-      | (rawPlain, rawEncoded) <- testData,
-        -- For lazy ByteStrings, we want to check not only ["foo"], but
+      | (rawPlain, rawEncoded) <- testData
+      , -- For lazy ByteStrings, we want to check not only ["foo"], but
         -- also ["f","oo"], ["f", "o", "o"] and ["fo", "o"]. The
         -- allRepresentations function gives us all representations of a
         -- lazy ByteString.
-        plain   <- allRepresentations rawPlain,
-        let encoded_plain = enc plain
+        plain <- allRepresentations rawPlain
+      , let encoded_plain = enc plain
       ] ++
-      [ testCase ("base64-string: Decode " ++ show encoded)
-                 (decoded_encoded @?= Right rawPlain)
-      | (rawPlain, rawEncoded) <- testData,
-        -- Again, we need to try all representations of lazy ByteStrings.
-        encoded <- allRepresentations rawEncoded,
-        let decoded_encoded = dec encoded
+      [ testCase ("base64-string: Decode " ++ show encoded) (decoded_encoded @?= Right rawPlain)
+      | (rawPlain, rawEncoded) <- testData
+      , -- Again, we need to try all representations of lazy ByteStrings.
+        encoded <- allRepresentations rawEncoded
+      , let decoded_encoded = dec encoded
       ]
 
 class AllRepresentations a where
@@ -312,7 +311,6 @@ paddingCoherenceTests = testGroup "padded/unpadded coherence"
           Right s
         assertEqual "String has no padding: decodes should coincide" v $
           Right s
-        assertEqual "String has no padding: decodes should coincide" v u
 
     nopadtest s t = testCase (show $ if t == "" then "empty" else t) $ do
         let u = Base64URL.decodePadded t
@@ -325,7 +323,6 @@ paddingCoherenceTests = testGroup "padded/unpadded coherence"
             Right s
           assertEqual "String has no padding: decodes should coincide" v $
             Right s
-          assertEqual "String has no padding: decodes should coincide" v u
         else do
           assertEqual "Unpadded required: padding fails" u $
             Left "Base64-encoded bytestring required to be padded"


### PR DESCRIPTION
FYI @23Skidoo @hvr 

This PR adds the following: 

- Addresses a small bug in the `doPad` portion of the code that padded out the optionally padded Base64url strings to a multiple of 4. There's a subtle thing I missed in my previous implementation which causes strings of length l = 1 mod 4 to be padded (i.e. 3 padding chars were added). This is never a valid length for inputs. Inputs fail at decode time, but the length errors should be caught at the head. Likewise, so should padding chars at the end of the string if an unpadded input requests strict unpadded behavior when decoding.

- Adds `decodeUnpadded` which validates a Base64url-encoded bytestring for size and correct lack of padding (i.e. proper length _and_ last two chars are not padding chars). 

- Adds `decodePadded` which enforces the length of the string is 0 mod 4 (as before)

- Lazy variants are implemented as well as strict variants.