### PR TITLE
[Bugfix] Padding chars no longer allowed anywhere but the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.0.1.0
+# 1.1.0.0
 
-* The default behavior for Base64url `decode` is now to support arbitrary padding. If you need strict padded or unpadded decode semantics, use `decodePadded` or `decodeUnpadded`. 
+* Bugfix: `decode` formerly allowed for padding chars to be interspersed in a valid base64-encoded string. This is now not the case, and it is fully spec-compliant as of [#31](https://github.com/haskell/base64-bytestring/pull/31)
+* The default behavior for Base64url `decode` is now to support arbitrary padding. If you need strict padded or unpadded decode semantics, use `decodePadded` or `decodeUnpadded`.
 * Added strict unpadded and padded decode functions for Base64url ([#30](https://github.com/haskell/base64-bytestring/pull/30))
 * Added unpadded encode for Base64url
   ([#26](https://github.com/haskell/base64-bytestring/pull/26)).

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE MultiWayIf #-}
 -- |
 -- Module      : Data.ByteString.Base64.Internal
 -- Copyright   : (c) 2010 Bryan O'Sullivan
@@ -243,65 +242,65 @@ decodeLoop !dtable !sptr !dptr !end !dfp = go dptr sptr 0
       return (fromIntegral v)
 
     go !dst !src !n
-      | plusPtr src 4 >= end = finish dst src n
+      | plusPtr src 4 >= end = do
+        !a <- look src
+        !b <- look (src `plusPtr` 1)
+        !c <- look (src `plusPtr` 2)
+        !d <- look (src `plusPtr` 3)
+        finalChunk dst src n a b c d
+
       | otherwise = do
         !a <- look src
         !b <- look (src `plusPtr` 1)
         !c <- look (src `plusPtr` 2)
         !d <- look (src `plusPtr` 3)
+        decodeChunk dst src n a b c d
 
-        if
-          | a == 0x63 -> padErr src
-          | b == 0x63 -> padErr (plusPtr src 1)
-          | c == 0x63 -> padErr (plusPtr src 2)
-          | d == 0x63 -> padErr (plusPtr src 3)
-          | a == 0xff -> err src
-          | b == 0xff -> err (plusPtr src 1)
-          | c == 0xff -> err (plusPtr src 2)
-          | d == 0xff -> err (plusPtr src 3)
-          | otherwise -> do
+    decodeChunk !dst !src !n !a !b !c !d
+     | a == 0x63 = padErr src
+     | b == 0x63 = padErr (plusPtr src 1)
+     | c == 0x63 = padErr (plusPtr src 2)
+     | d == 0x63 = padErr (plusPtr src 3)
+     | a == 0xff = err src
+     | b == 0xff = err (plusPtr src 1)
+     | c == 0xff = err (plusPtr src 2)
+     | d == 0xff = err (plusPtr src 3)
+     | otherwise = do
+       let !w = ((unsafeShiftL a 18)
+             .|. (unsafeShiftL b 12)
+             .|. (unsafeShiftL c 6)
+             .|. d) :: Word32
 
-            let !w = ((unsafeShiftL a 18)
-                  .|. (unsafeShiftL b 12)
-                  .|. (unsafeShiftL c 6)
-                  .|. d) :: Word32
+       poke8 dst (fromIntegral (unsafeShiftR w 16))
+       poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
+       poke8 (plusPtr dst 2) (fromIntegral w)
+       go (plusPtr dst 3) (plusPtr src 4) (n + 3)
 
-            poke8 dst (fromIntegral (unsafeShiftR w 16))
+    finalChunk !dst !src !n a b c d
+      | a == 0x63 = padErr src
+      | b == 0x63 = padErr (plusPtr src 1)
+      | a == 0xff = err src
+      | b == 0xff = err (plusPtr src 1)
+      | c == 0xff = err (plusPtr src 2)
+      | d == 0xff = err (plusPtr src 3)
+      | otherwise = do
+        let !w = ((unsafeShiftL a 18)
+              .|. (unsafeShiftL b 12)
+              .|. (unsafeShiftL c 6)
+              .|. d) :: Word32
+
+        poke8 dst (fromIntegral (unsafeShiftR w 16))
+
+        if c == 0x63
+        then return $ Right (PS dfp 0 (n + 1))
+        else if d == 0x63
+          then do
+            poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
+            return $ Right (PS dfp 0 (n + 2))
+          else do
             poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
             poke8 (plusPtr dst 2) (fromIntegral w)
-            go (plusPtr dst 3) (plusPtr src 4) (n + 3)
-
-    finish !dst !src !n = do
-      !a <- look src
-      !b <- look (src `plusPtr` 1)
-      !c <- look (src `plusPtr` 2)
-      !d <- look (src `plusPtr` 3)
-
-      if
-        | a == 0x63 -> padErr src
-        | b == 0x63 -> padErr (plusPtr src 1)
-        | a == 0xff -> err src
-        | b == 0xff -> err (plusPtr src 1)
-        | c == 0xff -> err (plusPtr src 2)
-        | d == 0xff -> err (plusPtr src 3)
-        | otherwise -> do
-
-          let !w = ((unsafeShiftL a 18)
-                .|. (unsafeShiftL b 12)
-                .|. (unsafeShiftL c 6)
-                .|. d) :: Word32
-
-          poke8 dst (fromIntegral (unsafeShiftR w 16))
-
-          if
-            | c == 0x63 -> return $ Right (PS dfp 0 (n + 1))
-            | d == 0x63 -> do
-              poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
-              return $ Right (PS dfp 0 (n + 2))
-            | otherwise -> do
-              poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
-              poke8 (plusPtr dst 2) (fromIntegral w)
-              return $ Right (PS dfp 0 (n + 3))
+            return $ Right (PS dfp 0 (n + 3))
 
 -- | Decode a base64-encoded string.  This function is lenient in
 -- following the specification from

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -209,14 +209,8 @@ decodeWithTable padding decodeFP bs@(PS !fp !o !l) = unsafePerformIO $
       dfp <- mallocByteString dlen
       withForeignPtr decodeFP $ \ !decptr ->
         withForeignPtr sfp $ \sptr ->
-        withForeignPtr dfp $ \dptr -> do
-          let !end = sptr `plusPtr` (slen + soff)
-          decodeLoop
-            decptr
-            (plusPtr sptr soff)
-            dptr
-            end
-            dfp
+        withForeignPtr dfp $ \dptr ->
+          decodeLoop decptr (plusPtr sptr soff) dptr (sptr `plusPtr` (slen + soff)) dfp
 
 decodeLoop
     :: Ptr Word8

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -24,7 +24,7 @@ module Data.ByteString.Base64.Internal
     , Padding(..)
     ) where
 
-import Data.Bits ((.|.), (.&.), shiftL, shiftR, unsafeShiftL, unsafeShiftR)
+import Data.Bits ((.|.), (.&.), shiftL, shiftR)
 import qualified Data.ByteString as B
 import Data.ByteString.Internal (ByteString(..), mallocByteString, memcpy,
                                  unsafeCreate)
@@ -269,13 +269,13 @@ decodeLoop !dtable !sptr !dptr !end !dfp = go dptr sptr
      | c == 0xff = err (plusPtr src 2)
      | d == 0xff = err (plusPtr src 3)
      | otherwise = do
-       let !w = ((unsafeShiftL a 18)
-             .|. (unsafeShiftL b 12)
-             .|. (unsafeShiftL c 6)
+       let !w = ((shiftL a 18)
+             .|. (shiftL b 12)
+             .|. (shiftL c 6)
              .|. d) :: Word32
 
-       poke8 dst (fromIntegral (unsafeShiftR w 16))
-       poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
+       poke8 dst (fromIntegral (shiftR w 16))
+       poke8 (plusPtr dst 1) (fromIntegral (shiftR w 8))
        poke8 (plusPtr dst 2) (fromIntegral w)
        go (plusPtr dst 3) (plusPtr src 4)
 
@@ -292,21 +292,21 @@ decodeLoop !dtable !sptr !dptr !end !dfp = go dptr sptr
       | c == 0xff = err (plusPtr src 2)
       | d == 0xff = err (plusPtr src 3)
       | otherwise = do
-        let !w = ((unsafeShiftL a 18)
-              .|. (unsafeShiftL b 12)
-              .|. (unsafeShiftL c 6)
+        let !w = ((shiftL a 18)
+              .|. (shiftL b 12)
+              .|. (shiftL c 6)
               .|. d) :: Word32
 
-        poke8 dst (fromIntegral (unsafeShiftR w 16))
+        poke8 dst (fromIntegral (shiftR w 16))
 
         if c == 0x63 && d == 0x63
         then return $ Right $ PS dfp 0 (1 + (dst `minusPtr` dptr))
         else if d == 0x63
           then do
-            poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
+            poke8 (plusPtr dst 1) (fromIntegral (shiftR w 8))
             return $ Right $ PS dfp 0 (2 + (dst `minusPtr` dptr))
           else do
-            poke8 (plusPtr dst 1) (fromIntegral (unsafeShiftR w 8))
+            poke8 (plusPtr dst 1) (fromIntegral (shiftR w 8))
             poke8 (plusPtr dst 2) (fromIntegral w)
             return $ Right $ PS dfp 0 (3 + (dst `minusPtr` dptr))
 

--- a/base64-bytestring.cabal
+++ b/base64-bytestring.cabal
@@ -37,7 +37,7 @@ library
 
   build-depends:
     base == 4.*,
-    bytestring >= 0.9.0
+    bytestring >= 0.9 && < 0.11
 
   ghc-options: -Wall -funbox-strict-fields
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -292,6 +292,9 @@ paddingCoherenceTests = testGroup "padded/unpadded coherence"
       , nopadtest "<<??>" "PDw_Pz4"
       , nopadtest "<<??>>" "PDw_Pz4-"
       ]
+    , testGroup "Padding validity"
+      [ interpaddingTest
+      ]
     ]
   where
     padtest s t = testCase (show $ if t == "" then "empty" else t) $ do
@@ -329,3 +332,11 @@ paddingCoherenceTests = testGroup "padded/unpadded coherence"
 
           assertEqual "Unpadded required: unpadding succeeds" v $
             Right s
+
+    interpaddingTest = testCase "Padding fails everywhere but end" $ do
+      Base64.decode "=eAoeAo=" @=? Left "invalid padding at offset: 0"
+      Base64.decode "e=AoeAo=" @=? Left "invalid padding at offset: 1"
+      Base64.decode "eA=oeAo=" @=? Left "invalid padding at offset: 2"
+      Base64.decode "eAo=eAo=" @=? Left "invalid padding at offset: 3"
+      Base64.decode "eAoe=Ao=" @=? Left "invalid padding at offset: 4"
+      Base64.decode "eAoeA=o=" @=? Left "invalid padding at offset: 5"


### PR DESCRIPTION
This is a bit of a surprising bug in `base64-bytestring`: 

```haskell
> decode "eAo=eAo="
Right "x\n"

> decode "eAo=" ==  decode "eAo=eAo="
True
```

It stems from the fact that the decode algorithm is just _wrong_: it does not check that no padding chars occur in the first and second positions of the 32 bytes read off in each step of the decoding process! This PR fixes that, improves error reporting, and also improves performance by separating concerns in the decode routine to consider head, inner loop, and tail separately. 