### PR TITLE
Add check for degenerate padded case in decode

### DIFF
--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -144,7 +144,7 @@ decodeWithTable padding decodeFP bs =
      Unpadded
        | r == 0 -> validateLastPad bs noPad $ go bs
        | r == 2 -> validateLastPad bs noPad $ go (B.append bs (B.replicate 2 0x3d))
-       | r == 3 -> validateLastPad bs invalidPad $ go (B.append bs (B.replicate 1 0x3d))
+       | r == 3 -> validateLastPad bs noPad $ go (B.append bs (B.replicate 1 0x3d))
        | otherwise -> Left "Base64-encoded bytestring has invalid size"
   where
     (!q, !r) = (B.length bs) `divMod` 4

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -144,7 +144,7 @@ decodeWithTable padding decodeFP bs =
      Unpadded
        | r == 0 -> validateLastPad bs noPad $ go bs
        | r == 2 -> validateLastPad bs noPad $ go (B.append bs (B.replicate 2 0x3d))
-       | r == 3 -> validateLastPad bs noPad $ go (B.append bs (B.replicate 1 0x3d))
+       | r == 3 -> validateLastPad bs invalidPad $ go (B.append bs (B.replicate 1 0x3d))
        | otherwise -> Left "Base64-encoded bytestring has invalid size"
   where
     (!q, !r) = (B.length bs) `divMod` 4

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -133,9 +133,10 @@ decodeWithTable _ _ (PS _ _ 0) = Right B.empty
 decodeWithTable padding decodeFP bs =
    case padding of
      Padded
-       | r == 1 -> Left "Base64-encoded bytestring has invalid size"
-       | r /= 0 -> Left "Base64-encoded bytestring required to be padded"
-       | otherwise -> unsafePerformIO $ go bs
+       | r == 0 -> unsafePerformIO $ go bs
+       | r == 2 -> Left "Base64-encoded bytestring required to be padded"
+       | r == 3 -> Left "Base64-encoded bytestring has invalid padding"
+       | otherwise -> Left "Base64-encoded bytestring has invalid size"
      Don'tCare
        | r == 0 -> unsafePerformIO $ go bs
        | r == 2 -> unsafePerformIO $ go (B.append bs (B.replicate 2 0x3d))

--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -134,9 +134,8 @@ decodeWithTable padding decodeFP bs =
    case padding of
      Padded
        | r == 0 -> unsafePerformIO $ go bs
-       | r == 2 -> Left "Base64-encoded bytestring required to be padded"
-       | r == 3 -> Left "Base64-encoded bytestring has invalid padding"
-       | otherwise -> Left "Base64-encoded bytestring has invalid size"
+       | r == 1 -> Left "Base64-encoded bytestring has invalid size"
+       | otherwise -> Left "Base64-encoded bytestring is unpadded or has invalid padding"
      Don'tCare
        | r == 0 -> unsafePerformIO $ go bs
        | r == 2 -> unsafePerformIO $ go (B.append bs (B.replicate 2 0x3d))

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -367,8 +367,13 @@ base64UrlUnitTests = testGroup "Base64URL unit tests"
           assertEqual "String has no padding: decodes should coincide" v $
             Right s
         else do
-          assertEqual "Unpadded required: padding fails" u $
-            Left "Base64-encoded bytestring required to be padded"
+          if BS.length t `mod` 4 == 3
+          then do
+            assertEqual "Unpadded required: padding fails" u $
+              Left "Base64-encoded bytestring has invalid padding"
+          else do
+            assertEqual "Unpadded required: padding fails" u $
+              Left "Base64-encoded bytestring required to be padded"
 
           assertEqual "Unpadded required: unpadding succeeds" v $
             Right s
@@ -471,8 +476,13 @@ lazyBase64UrlUnitTests = testGroup "LBase64URL unit tests"
           assertEqual "String has no padding: decodes should coincide" v $
             Right s
         else do
-          assertEqual "Unpadded required: padding fails" u $
-            Left "Base64-encoded bytestring required to be padded"
+          if L.length t `mod` 4 == 3
+          then do
+            assertEqual "Unpadded required: padding fails" u $
+              Left "Base64-encoded bytestring has invalid padding"
+          else do
+            assertEqual "Unpadded required: padding fails" u $
+              Left "Base64-encoded bytestring required to be padded"
 
           assertEqual "Unpadded required: unpadding succeeds" v $
             Right s

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -367,13 +367,8 @@ base64UrlUnitTests = testGroup "Base64URL unit tests"
           assertEqual "String has no padding: decodes should coincide" v $
             Right s
         else do
-          if BS.length t `mod` 4 == 3
-          then do
-            assertEqual "Unpadded required: padding fails" u $
-              Left "Base64-encoded bytestring has invalid padding"
-          else do
-            assertEqual "Unpadded required: padding fails" u $
-              Left "Base64-encoded bytestring required to be padded"
+          assertEqual "Unpadded required: padding fails" u $
+            Left "Base64-encoded bytestring is unpadded or has invalid padding"
 
           assertEqual "Unpadded required: unpadding succeeds" v $
             Right s
@@ -476,13 +471,8 @@ lazyBase64UrlUnitTests = testGroup "LBase64URL unit tests"
           assertEqual "String has no padding: decodes should coincide" v $
             Right s
         else do
-          if L.length t `mod` 4 == 3
-          then do
-            assertEqual "Unpadded required: padding fails" u $
-              Left "Base64-encoded bytestring has invalid padding"
-          else do
-            assertEqual "Unpadded required: padding fails" u $
-              Left "Base64-encoded bytestring required to be padded"
+          assertEqual "Unpadded required: padding fails" u $
+            Left "Base64-encoded bytestring is unpadded or has invalid padding"
 
           assertEqual "Unpadded required: unpadding succeeds" v $
             Right s


### PR DESCRIPTION
This removes the odd inconsistency between failure modes for URL where degenerate inputs like `Z3==` pass `decode`, but not `decodeUnpadded` and `decodePadded`. Addresses #35 

before: 

```haskell
П> U.decode "ZE="
Right "d"
П> U.decodeUnpadded  "ZE="
Left "Base64-encoded bytestring required to be unpadded"
П> U.decodePadded  "ZE="
Left "Base64-encoded bytestring required to be padded"
```

after (note the subtlety in the messages returned): 

```haskell
П> U.decode "ZE="
Left "Base64-encoded bytestring has invalid padding"
П> U.decodeUnpadded  "ZE="
Left "Base64-encoded bytestring required to be unpadded"
П> U.decodePadded  "ZE="
Left "Base64-encoded bytestring has invalid padding"
П> U.decode "ZE=="
Right "d"
П> U.decodeUnpadded  "ZE=="
Left "Base64-encoded bytestring required to be unpadded"
П> U.decodePadded  "ZE=="
Right "d"
П> U.decode "ZE"
Right "d"
П> U.decodeUnpadded  "ZE"
Right "d"
П> U.decodePadded  "ZE"
Left "Base64-encoded bytestring required to be padded"
```

TODO: 

- [x] property tests for interplay between decodes
