### PR TITLE
malloc enough space for decoded string

### DIFF
--- a/Data/ByteString/Base64/Internal.hs
+++ b/Data/ByteString/Base64/Internal.hs
@@ -160,7 +160,7 @@ decodeWithTable padding !decodeFP bs
     noPad = "Base64-encoded bytestring required to be unpadded"
     invalidPad = "Base64-encoded bytestring has invalid padding"
 
-    !dlen = q * 3
+    !dlen = (q + signum r) * 3
 
     go !sptr !slen = do
       dfp <- mallocByteString dlen


### PR DESCRIPTION
When decoding unpadded base64url, decodeWithTable does not allocate
enough space for the decoded string.  This results in memory
corruption.

Fixes: https://github.com/haskell/base64-bytestring/issues/44